### PR TITLE
13 fix how font is aligned vertically

### DIFF
--- a/build/generator.rs
+++ b/build/generator.rs
@@ -6,8 +6,6 @@ pub mod vec2;
 
 use font::Metrics;
 
-#[derive(Debug)]
-#[allow(dead_code)]
 pub struct GlyphEntry {
     pub name: String,
     pub px: u32,

--- a/build/generator/font.rs
+++ b/build/generator/font.rs
@@ -62,7 +62,6 @@ pub struct Font {
     #[allow(dead_code)]
     name: Option<String>,
     glyphs: HashMap<char, Glyph>,
-    #[allow(dead_code)]
     horizontal_line_metrics: LineMetrics,
     units_per_em: f32,
 }
@@ -172,6 +171,14 @@ impl Font {
 
     fn scale_factor(&self, px: f32) -> f32 {
         px / self.units_per_em
+    }
+
+    pub fn get_ascent(&self, px: f32) -> i32 {
+        (self.horizontal_line_metrics.ascent * self.scale_factor(px)) as i32
+    }
+
+    pub fn get_descent(&self, px: f32) -> i32 {
+        (self.horizontal_line_metrics.descent * self.scale_factor(px)) as i32
     }
 }
 

--- a/build/renderer.rs
+++ b/build/renderer.rs
@@ -39,6 +39,8 @@ pub fn render(loaded_fonts: Vec<FontLoaded>) -> String {
 
         fonts_meta.push(context! {
             name => loaded_font.name,
+            ascent => loaded_font.font.get_ascent(loaded_font.px as f32),
+            descent => loaded_font.font.get_descent(loaded_font.px as f32),
             glyphs => glyphs,
         });
     }

--- a/examples/glyphr_test_window.rs
+++ b/examples/glyphr_test_window.rs
@@ -32,12 +32,24 @@ fn put_pixel(x: u32, y: u32, color: u32, buffer: &mut [u32]) {
 }
 
 fn test_pixel_buffer_with_window() {
+    use glyphr::fonts::{HFontAlign, VFontAlign};
+
     let mut buffer: [u32; WIDTH * HEIGHT] = [0; WIDTH * HEIGHT];
 
-    let mut window = Window::new("Pixel Buffer Test", WIDTH, HEIGHT, WindowOptions {
-        ..WindowOptions::default()
-    })
+    let mut window = Window::new(
+        "Pixel Buffer Test",
+        WIDTH,
+        HEIGHT,
+        WindowOptions {
+            ..WindowOptions::default()
+        },
+    )
     .expect("Failed to create window");
+    for x in 0..WIDTH {
+        buffer[120 * WIDTH + x] = 0xffffffff;
+        buffer[240 * WIDTH + x] = 0xffffffff;
+        buffer[360 * WIDTH + x] = 0xffffffff;
+    }
 
     let mut current = Glyphr::new(
         put_pixel,
@@ -46,13 +58,22 @@ fn test_pixel_buffer_with_window() {
         HEIGHT as u32,
         SdfConfig {
             color: 0x00ffffff,
-            px: 70,
+            px: 64,
             smoothing: 0.3,
-            align: glyphr::fonts::FontAlign::Center,
+            halign: HFontAlign::Left,
+            valign: VFontAlign::Baseline,
             ..Default::default()
         },
     );
-    current.render("test up & down!", 400, 1);
+    current.render("test base left!", 0, 120);
+
+    current.set_font_halign(HFontAlign::Center);
+    current.set_font_valign(VFontAlign::Center);
+    current.render("test center center!", 400, 240);
+
+    current.set_font_halign(HFontAlign::Right);
+    current.set_font_valign(VFontAlign::Top);
+    current.render("test top right!", 800, 360);
 
     while window.is_open() && !window.is_key_down(minifb::Key::Escape) {
         window.update_with_buffer(&buffer, WIDTH, HEIGHT).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,6 @@ pub mod renderer;
 pub mod sdf;
 pub mod utils;
 
-pub use fonts::{Font, FontAlign};
+pub use fonts::{Font, VFontAlign, HFontAlign};
 pub use glyph::{OutlineBounds, GlyphEntry, Metrics};
 pub use renderer::{Buffer, Glyphr, SdfConfig};

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -71,7 +71,7 @@ impl<'a> Glyphr<'a> {
     ///
     /// # Examples
     /// ```
-    /// use glyphr::{Glyphr, SdfConfig, Font, FontAlign};
+    /// use glyphr::{Glyphr, SdfConfig, Font, VFontAlign, HFontAlign};
     ///
     /// let mut buf = [0u32, 100];
     /// let config =  SdfConfig {
@@ -79,7 +79,8 @@ impl<'a> Glyphr<'a> {
     ///     px: 70,
     ///     smoothing: 0.4,
     ///     mid_value: 0.5,
-    ///     align: FontAlign::Center,
+    ///     halign: HFontAlign::Center,
+    ///     valign: VFontAlign::Top,
     ///     font: Font::default(),
     /// };
     /// let glyphr_struct = Glyphr::new(|_, _, _, _| (), &mut buf, 10, 10, config);
@@ -107,7 +108,7 @@ impl<'a> Glyphr<'a> {
     ///
     /// # Examples
     /// ```
-    /// use glyphr::{Glyphr, SdfConfig, Font, FontAlign};
+    /// use glyphr::{Glyphr, SdfConfig, Font, VFontAlign, HFontAlign};
     ///
     /// let mut buf = [0u32, 100];
     /// let config =  SdfConfig {
@@ -115,7 +116,8 @@ impl<'a> Glyphr<'a> {
     ///     px: 70,
     ///     smoothing: 0.4,
     ///     mid_value: 0.5,
-    ///     align: FontAlign::Center,
+    ///     halign: HFontAlign::Center,
+    ///     valign: VFontAlign::Top,
     ///     font: Font::default(),
     /// };
     /// let mut glyphr_struct = Glyphr::new(|_, _, _, _| (), &mut buf, 10, 10, config);
@@ -125,7 +127,8 @@ impl<'a> Glyphr<'a> {
     ///     px: 110,
     ///     smoothing: 1.0,
     ///     mid_value: 0.5,
-    ///     align: FontAlign::Left,
+    ///     halign: HFontAlign::Left,
+    ///     valign: VFontAlign::Baseline,
     ///     font: Font::default(),
     /// };
     ///
@@ -140,7 +143,7 @@ impl<'a> Glyphr<'a> {
     ///
     /// # Examples
     /// ```
-    /// use glyphr::{Glyphr, SdfConfig, Font, FontAlign};
+    /// use glyphr::{Glyphr, SdfConfig, Font, VFontAlign, HFontAlign};
     ///
     /// let mut buf = [0u32, 100];
     /// let config =  SdfConfig {
@@ -148,7 +151,8 @@ impl<'a> Glyphr<'a> {
     ///     px: 70,
     ///     smoothing: 0.4,
     ///     mid_value: 0.5,
-    ///     align: FontAlign::Center,
+    ///     halign: HFontAlign::Center,
+    ///     valign: VFontAlign::Top,
     ///     font: Font::default(),
     /// };
     /// let mut glyphr_struct = Glyphr::new(|_, _, _, _| (), &mut buf, 10, 10, config);
@@ -164,7 +168,7 @@ impl<'a> Glyphr<'a> {
     ///
     /// # Examples
     /// ```
-    /// use glyphr::{Glyphr, SdfConfig, Font, VFontAlign};
+    /// use glyphr::{Glyphr, SdfConfig, Font, VFontAlign, HFontAlign};
     ///
     /// let mut buf = [0u32, 100];
     /// let config =  SdfConfig {
@@ -172,13 +176,13 @@ impl<'a> Glyphr<'a> {
     ///     px: 70,
     ///     smoothing: 0.4,
     ///     mid_value: 0.5,
-    ///     valign: HFontAlign::Center,
-    ///     halign: VFontAlign::default(),
+    ///     halign: HFontAlign::Center,
+    ///     valign: VFontAlign::Top,
     ///     font: Font::default(),
     /// };
     /// let mut glyphr_struct = Glyphr::new(|_, _, _, _| (), &mut buf, 10, 10, config);
     ///
-    /// glyphr_struct.set_font_halign(VFontAlign::Left);
+    /// glyphr_struct.set_font_halign(HFontAlign::Left);
     /// assert_eq!(glyphr_struct.sdf_config.halign, HFontAlign::Left);
     /// ```
     pub fn set_font_halign(&mut self, align: HFontAlign) {
@@ -189,7 +193,7 @@ impl<'a> Glyphr<'a> {
     ///
     /// # Examples
     /// ```
-    /// use glyphr::{Glyphr, SdfConfig, Font, VFontAlign};
+    /// use glyphr::{Glyphr, SdfConfig, Font, VFontAlign, HFontAlign};
     ///
     /// let mut buf = [0u32, 100];
     /// let config =  SdfConfig {
@@ -197,14 +201,14 @@ impl<'a> Glyphr<'a> {
     ///     px: 70,
     ///     smoothing: 0.4,
     ///     mid_value: 0.5,
-    ///     valign: VFontAlign::Center,
-    ///     halign: HFontAlign::default(),
+    ///     halign: HFontAlign::Center,
+    ///     valign: VFontAlign::Top,
     ///     font: Font::default(),
     /// };
     /// let mut glyphr_struct = Glyphr::new(|_, _, _, _| (), &mut buf, 10, 10, config);
     ///
-    /// glyphr_struct.set_font_valign(VFontAlign::Left);
-    /// assert_eq!(glyphr_struct.sdf_config.valign, VFontAlign::Left);
+    /// glyphr_struct.set_font_valign(VFontAlign::Baseline);
+    /// assert_eq!(glyphr_struct.sdf_config.valign, VFontAlign::Baseline);
     /// ```
     pub fn set_font_valign(&mut self, align: VFontAlign) {
         self.sdf_config.valign = align;
@@ -214,7 +218,7 @@ impl<'a> Glyphr<'a> {
     ///
     /// # Examples
     /// ```
-    /// use glyphr::{Glyphr, SdfConfig, Font, FontAlign};
+    /// use glyphr::{Glyphr, SdfConfig, Font, VFontAlign, HFontAlign};
     ///
     /// let mut buf = [0u32, 100];
     /// let config =  SdfConfig {
@@ -222,7 +226,8 @@ impl<'a> Glyphr<'a> {
     ///     px: 70,
     ///     smoothing: 0.4,
     ///     mid_value: 0.5,
-    ///     align: FontAlign::Center,
+    ///     halign: HFontAlign::Center,
+    ///     valign: VFontAlign::Top,
     ///     font: Font::default(),
     /// };
     /// let mut glyphr_struct = Glyphr::new(|_, _, _, _| (), &mut buf, 10, 10, config);
@@ -238,7 +243,7 @@ impl<'a> Glyphr<'a> {
     ///
     /// # Examples
     /// ```
-    /// use glyphr::{Glyphr, SdfConfig, Font, FontAlign};
+    /// use glyphr::{Glyphr, SdfConfig, Font, VFontAlign, HFontAlign};
     ///
     /// let mut buf = [0u32, 100];
     /// let config =  SdfConfig {
@@ -246,7 +251,8 @@ impl<'a> Glyphr<'a> {
     ///     px: 70,
     ///     smoothing: 0.4,
     ///     mid_value: 0.5,
-    ///     align: FontAlign::Center,
+    ///     halign: HFontAlign::Center,
+    ///     valign: VFontAlign::Top,
     ///     font: Font::default(),
     /// };
     /// let mut glyphr_struct = Glyphr::new(|_, _, _, _| (), &mut buf, 10, 10, config);
@@ -262,7 +268,7 @@ impl<'a> Glyphr<'a> {
     ///
     /// # Examples
     /// ```
-    /// use glyphr::{Glyphr, SdfConfig, Font, FontAlign};
+    /// use glyphr::{Glyphr, SdfConfig, Font, VFontAlign, HFontAlign};
     ///
     /// let mut buf = [0u32, 100];
     /// let config =  SdfConfig {
@@ -270,7 +276,8 @@ impl<'a> Glyphr<'a> {
     ///     px: 70,
     ///     smoothing: 0.4,
     ///     mid_value: 0.5,
-    ///     align: FontAlign::Center,
+    ///     halign: HFontAlign::Center,
+    ///     valign: VFontAlign::Top,
     ///     font: Font::default(),
     /// };
     /// let mut glyphr_struct = Glyphr::new(|_, _, _, _| (), &mut buf, 10, 10, config);
@@ -286,7 +293,7 @@ impl<'a> Glyphr<'a> {
     ///
     /// # Examples
     /// ```
-    /// use glyphr::{Glyphr, SdfConfig, Font, FontAlign};
+    /// use glyphr::{Glyphr, SdfConfig, Font, VFontAlign, HFontAlign};
     ///
     /// let mut buf = [0u32, 100];
     /// let config =  SdfConfig {
@@ -294,7 +301,8 @@ impl<'a> Glyphr<'a> {
     ///     px: 70,
     ///     smoothing: 0.4,
     ///     mid_value: 0.5,
-    ///     align: FontAlign::Center,
+    ///     halign: HFontAlign::Center,
+    ///     valign: VFontAlign::Top,
     ///     font: Font::default(),
     /// };
     /// let mut glyphr_struct = Glyphr::new(|_, _, _, _| (), &mut buf, 10, 10, config);
@@ -310,7 +318,7 @@ impl<'a> Glyphr<'a> {
     ///
     /// # Examples
     /// ```
-    /// use glyphr::{Glyphr, SdfConfig, Font, FontAlign};
+    /// use glyphr::{Glyphr, SdfConfig, Font, VFontAlign, HFontAlign};
     ///
     /// let mut buf = [0u32, 100];
     /// let config =  SdfConfig {
@@ -361,7 +369,7 @@ impl<'a> Glyphr<'a> {
     ///
     /// # Examples
     /// ```
-    /// use glyphr::{Glyphr, SdfConfig, Font, FontAlign};
+    /// use glyphr::{Glyphr, SdfConfig, Font, VFontAlign, HFontAlign};
     ///
     /// let mut buf = [0u32, 100];
     /// let config =  SdfConfig {
@@ -369,7 +377,8 @@ impl<'a> Glyphr<'a> {
     ///     px: 20,
     ///     smoothing: 0.4,
     ///     mid_value: 0.5,
-    ///     align: FontAlign::Left,
+    ///     halign: HFontAlign::Left,
+    ///     valign: VFontAlign::Top,
     ///     font: Font::default(),
     /// };
     /// let mut glyphr_struct = Glyphr::new(|_, _, _, _| (), &mut buf, 10, 10, config);

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -4,7 +4,7 @@
 //! Everything is done via the `Glyphr` struct.
 
 use crate::{
-    fonts::{Font, FontAlign},
+    fonts::{Font, HFontAlign, VFontAlign},
     sdf,
 };
 
@@ -16,7 +16,8 @@ type WritePixel = fn(u32, u32, u32, &mut [u32]);
 #[derive(Clone, Copy)]
 pub struct SdfConfig {
     pub font: Font,
-    pub align: FontAlign,
+    pub valign: VFontAlign,
+    pub halign: HFontAlign,
     pub px: u32,
     pub color: u32,
     pub mid_value: f32,
@@ -36,7 +37,8 @@ impl Default for SdfConfig {
     fn default() -> Self {
         Self {
             font: Font::default(),
-            align: FontAlign::default(),
+            valign: VFontAlign::default(),
+            halign: HFontAlign::default(),
             px: Font::default().get_size() as u32,
             color: 0x000000,
             mid_value: 0.5,
@@ -158,11 +160,11 @@ impl<'a> Glyphr<'a> {
         self.sdf_config.font = font;
     }
 
-    /// # set_font_align
+    /// # set_font_valign
     ///
     /// # Examples
     /// ```
-    /// use glyphr::{Glyphr, SdfConfig, Font, FontAlign};
+    /// use glyphr::{Glyphr, SdfConfig, Font, VFontAlign};
     ///
     /// let mut buf = [0u32, 100];
     /// let config =  SdfConfig {
@@ -170,16 +172,42 @@ impl<'a> Glyphr<'a> {
     ///     px: 70,
     ///     smoothing: 0.4,
     ///     mid_value: 0.5,
-    ///     align: FontAlign::Center,
+    ///     valign: HFontAlign::Center,
+    ///     halign: VFontAlign::default(),
     ///     font: Font::default(),
     /// };
     /// let mut glyphr_struct = Glyphr::new(|_, _, _, _| (), &mut buf, 10, 10, config);
     ///
-    /// glyphr_struct.set_font_align(FontAlign::Left);
-    /// assert_eq!(glyphr_struct.sdf_config.align, FontAlign::Left);
+    /// glyphr_struct.set_font_halign(VFontAlign::Left);
+    /// assert_eq!(glyphr_struct.sdf_config.halign, HFontAlign::Left);
     /// ```
-    pub fn set_font_align(&mut self, align: FontAlign) {
-        self.sdf_config.align = align;
+    pub fn set_font_halign(&mut self, align: HFontAlign) {
+        self.sdf_config.halign = align;
+    }
+
+    /// # set_font_valign
+    ///
+    /// # Examples
+    /// ```
+    /// use glyphr::{Glyphr, SdfConfig, Font, VFontAlign};
+    ///
+    /// let mut buf = [0u32, 100];
+    /// let config =  SdfConfig {
+    ///     color: 0xffffff,
+    ///     px: 70,
+    ///     smoothing: 0.4,
+    ///     mid_value: 0.5,
+    ///     valign: VFontAlign::Center,
+    ///     halign: HFontAlign::default(),
+    ///     font: Font::default(),
+    /// };
+    /// let mut glyphr_struct = Glyphr::new(|_, _, _, _| (), &mut buf, 10, 10, config);
+    ///
+    /// glyphr_struct.set_font_valign(VFontAlign::Left);
+    /// assert_eq!(glyphr_struct.sdf_config.valign, VFontAlign::Left);
+    /// ```
+    pub fn set_font_valign(&mut self, align: VFontAlign) {
+        self.sdf_config.valign = align;
     }
 
     /// # set_size
@@ -290,7 +318,8 @@ impl<'a> Glyphr<'a> {
     ///     px: 20,
     ///     smoothing: 0.4,
     ///     mid_value: 0.5,
-    ///     align: FontAlign::Left,
+    ///     halign: HFontAlign::Left,
+    ///     valign: VFontAlign::Top,
     ///     font: Font::default(),
     /// };
     /// let mut glyphr_struct = Glyphr::new(|_, _, _, _| (), &mut buf, 10, 10, config);
@@ -299,24 +328,31 @@ impl<'a> Glyphr<'a> {
     /// assert!(buf.iter().any(|c| *c != 0));
     /// ```
     pub fn render(&mut self, phrase: &str, mut x: i32, y: i32) {
-        let mut heights: [i32; 100] = [0; 100];
-        let mut max_height = i32::MIN;
         let scale = self.sdf_config.px as f32 / self.sdf_config.font.get_size() as f32;
+        let ascent = self.sdf_config.font.get_ascent();
+        let descent = self.sdf_config.font.get_descent();
 
-        match self.sdf_config.align {
-            FontAlign::Center => x -= self.phrase_length(phrase) / 2,
-            FontAlign::Right => x -= self.phrase_length(phrase),
-            _ => {}
-        }
-        for (i, c) in phrase.chars().enumerate() {
-            if let Some(metrics) = sdf::get_metrics(self, c) {
-                let h = ((metrics.height + metrics.ymin) as f32 * scale) as i32;
-                max_height = max_height.max(h);
-                heights[i] = h;
+        let x_offset = match self.sdf_config.halign {
+            HFontAlign::Center => self.phrase_length(phrase) / 2,
+            HFontAlign::Right => self.phrase_length(phrase),
+            HFontAlign::Left => 0,
+        };
+
+        let y_offset = match self.sdf_config.valign {
+            VFontAlign::Top => (descent as f32 * scale) as i32,
+            VFontAlign::Center => {
+                let total_height = (ascent - descent) as f32 * scale;
+                -(total_height / 2.0) as i32
             }
-        }
-        for (i, c) in phrase.chars().enumerate() {
-            sdf::render_glyph(x, y + (max_height - heights[i]) as i32, c, self, scale);
+            VFontAlign::Baseline => -(ascent as f32 * scale) as i32,
+        };
+
+        for c in phrase.chars() {
+            if let Some(metrics) = sdf::get_metrics(self, c) {
+                let glyph_y =
+                    y + y_offset + ((ascent - metrics.ymin - metrics.height) as f32 * scale) as i32;
+                sdf::render_glyph(x - x_offset, glyph_y, c, self, scale);
+            }
             x += (sdf::advance(self, c).unwrap_or(0) as f32 * scale) as i32;
         }
     }
@@ -353,7 +389,7 @@ impl<'a> Glyphr<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fonts::{Font, FontAlign};
+    use crate::fonts::{Font, HFontAlign, VFontAlign};
 
     fn dummy_pixel_callback(x: u32, y: u32, color: u32, buf: &mut [u32]) {
         let idx = (y * 4 + x) as usize;
@@ -366,7 +402,8 @@ mod tests {
         let font = Font::default();
         SdfConfig {
             font,
-            align: FontAlign::Left,
+            halign: HFontAlign::Left,
+            valign: VFontAlign::Top,
             px: 24,
             color: 0xAABBCC,
             mid_value: 0.4,

--- a/src/sdf.rs
+++ b/src/sdf.rs
@@ -169,7 +169,8 @@ mod tests {
     fn setup_dummy_state<'a>(buffer: &'a mut [u32]) -> Glyphr<'a> {
         let config = SdfConfig {
             font: Font::default(),
-            align: crate::fonts::FontAlign::default(),
+            valign: crate::fonts::VFontAlign::default(),
+            halign: crate::fonts::HFontAlign::default(),
             px: 30,
             color: 0x112233,
             mid_value: 0.5,

--- a/templates/fonts.rs.j2
+++ b/templates/fonts.rs.j2
@@ -33,7 +33,14 @@ pub static FONT_{{ font.name|upper }}: [(char, GlyphEntry); {{ font.glyphs|lengt
 {%- endfor %}
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
-pub enum FontAlign {
+pub enum VFontAlign {
+    #[default] Top,
+    Center,
+    Baseline,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub enum HFontAlign {
     #[default] Left,
     Center,
     Right,
@@ -59,6 +66,9 @@ impl Font {
         }
     }
 
+    /// # get_size
+    ///
+    /// Returns the size of the generated font (the one decided by the user).
     pub fn get_size(&self) -> i32 {
         match self {
             {%- for font in fonts %}
@@ -66,6 +76,23 @@ impl Font {
             {%- endfor %}
         }
     }
+
+    pub fn get_ascent(&self) -> i32 {
+        match self {
+            {%- for font in fonts %}
+            Font::{{ font.name|capitalize }} => {{ font.ascent }},
+            {%- endfor %}
+        }
+    }
+
+    pub fn get_descent(&self) -> i32 {
+        match self {
+            {%- for font in fonts %}
+            Font::{{ font.name|capitalize }} => {{ font.descent }},
+            {%- endfor %}
+        }
+    }
+
 
     fn find_glyph(font: &[(char, GlyphEntry)], ch: char) -> Option<&GlyphEntry> {
         font.binary_search_by_key(&ch, |&(c, _)| c)


### PR DESCRIPTION
# What has been done?

- Added ascent and descent in font metrics (a method on the Font enumerator that returns ascent and descent in pixels).
- Using ascent and descent calculate position on y axis of the glyphs without more allocation than needed.
- An enumerator for vertical alignment, so that now users can decide what the y means (top, center, baseline)