### PR TITLE
17 error when trying to generate character apostrophe

### DIFF
--- a/glyphr-macros/Cargo.toml
+++ b/glyphr-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glyphr-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors = ["Alessandro Bridi <ale.bridi15@gmail.com>"]
 description = "Set of proc-macros used to generate fonts for glyphr"
@@ -14,7 +14,7 @@ proc-macro = true
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-toml = { version = "0.8.20"}
+toml = { version = "0.8.23"}
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/glyphr-macros/src/renderer.rs
+++ b/glyphr-macros/src/renderer.rs
@@ -10,7 +10,7 @@ fn rust_char_escape(value: Value) -> Result<String, minijinja::Error> {
         minijinja::Error::new(minijinja::ErrorKind::InvalidOperation, "expected string")
     })?;
     
-    if s.len() != 1 {
+    if s.chars().count() != 1 {
         return Err(minijinja::Error::new(
             minijinja::ErrorKind::InvalidOperation, 
             "expected single character"
@@ -81,4 +81,58 @@ pub fn render<T: ToFontLoaded>(font_config: T) -> String {
     }
 
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use minijinja::value::Value;
+
+    fn val(s: &str) -> Value {
+        Value::from(s.to_string())
+    }
+
+    #[test]
+    fn test_normal_char() {
+        assert_eq!(rust_char_escape(val("a")).unwrap(), "a");
+        assert_eq!(rust_char_escape(val("Z")).unwrap(), "Z");
+        assert_eq!(rust_char_escape(val("7")).unwrap(), "7");
+    }
+
+    #[test]
+    fn test_escape_chars() {
+        assert_eq!(rust_char_escape(val("'")).unwrap(), "\\'");
+        assert_eq!(rust_char_escape(val("\\")).unwrap(), "\\\\");
+        assert_eq!(rust_char_escape(val("\n")).unwrap(), "\\n");
+        assert_eq!(rust_char_escape(val("\r")).unwrap(), "\\r");
+        assert_eq!(rust_char_escape(val("\t")).unwrap(), "\\t");
+        assert_eq!(rust_char_escape(val("\0")).unwrap(), "\\0");
+    }
+
+    #[test]
+    fn test_control_char() {
+        // ASCII 0x01 (Start of Header)
+        assert_eq!(rust_char_escape(Value::from("\u{01}")).unwrap(), "\\u{0001}");
+    }
+
+    #[test]
+    fn test_unicode_non_escape() {
+        assert_eq!(rust_char_escape(Value::from("λ")).unwrap(), "λ");
+        assert_eq!(rust_char_escape(Value::from("🦀")).unwrap(), "🦀");
+    }
+
+    #[test]
+    fn test_invalid_length() {
+        let err = rust_char_escape(val("")).unwrap_err();
+        assert!(format!("{}", err).contains("expected single character"));
+
+        let err = rust_char_escape(val("ab")).unwrap_err();
+        assert!(format!("{}", err).contains("expected single character"));
+    }
+
+    #[test]
+    fn test_non_string_input() {
+        let err = rust_char_escape(Value::from(42)).unwrap_err();
+        assert!(format!("{}", err).contains("expected string"));
+    }
 }

--- a/glyphr-macros/src/renderer.rs
+++ b/glyphr-macros/src/renderer.rs
@@ -3,6 +3,8 @@ use minijinja::{Environment, context, Value};
 use crate::config::ToFontLoaded;
 use crate::generator::generate_font;
 
+/// Filter used by minijinja to escape characters that generates error if direcly placed inside
+/// apostrophes (e.g. `'`, `\`, `\n`...).
 fn rust_char_escape(value: Value) -> Result<String, minijinja::Error> {
     let s = value.as_str().ok_or_else(|| {
         minijinja::Error::new(minijinja::ErrorKind::InvalidOperation, "expected string")
@@ -30,7 +32,7 @@ fn rust_char_escape(value: Value) -> Result<String, minijinja::Error> {
     Ok(escaped)
 }
 
-/// Generates a String containing all the code to write out the macro
+/// Generates a String containing all the code to write out the macro.
 pub fn render<T: ToFontLoaded>(font_config: T) -> String {
     let loaded_fonts = font_config.to_font_loaded();
 

--- a/glyphr-macros/src/renderer.rs
+++ b/glyphr-macros/src/renderer.rs
@@ -1,13 +1,41 @@
-use minijinja::{Environment, context};
+use minijinja::{Environment, context, Value};
 
 use crate::config::ToFontLoaded;
 use crate::generator::generate_font;
+
+fn rust_char_escape(value: Value) -> Result<String, minijinja::Error> {
+    let s = value.as_str().ok_or_else(|| {
+        minijinja::Error::new(minijinja::ErrorKind::InvalidOperation, "expected string")
+    })?;
+    
+    if s.len() != 1 {
+        return Err(minijinja::Error::new(
+            minijinja::ErrorKind::InvalidOperation, 
+            "expected single character"
+        ));
+    }
+    
+    let ch = s.chars().next().unwrap();
+    let escaped = match ch {
+        '\'' => "\\'".to_string(),
+        '\\' => "\\\\".to_string(),
+        '\n' => "\\n".to_string(),
+        '\r' => "\\r".to_string(),
+        '\t' => "\\t".to_string(),
+        '\0' => "\\0".to_string(),
+        c if c.is_control() => format!("\\u{{{:04x}}}", c as u32),
+        c => c.to_string(),
+    };
+    
+    Ok(escaped)
+}
 
 /// Generates a String containing all the code to write out the macro
 pub fn render<T: ToFontLoaded>(font_config: T) -> String {
     let loaded_fonts = font_config.to_font_loaded();
 
     let mut env = Environment::new();
+    env.add_filter("rust_char_escape", rust_char_escape);
     env.add_template("fonts", include_str!("../templates/fonts.rs.j2"))
         .unwrap();
 

--- a/glyphr-macros/templates/fonts.rs.j2
+++ b/glyphr-macros/templates/fonts.rs.j2
@@ -9,7 +9,7 @@ static {{ glyph.codepoint }}_{{ font.name|upper }}: [u8; {{ glyph.bitmap_len }}]
 static GLYPHS_{{ font.name|upper }}: [::glyphr::Glyph; {{ font.glyphs|length }}] = [
     {%- for glyph in font.glyphs %}
     ::glyphr::Glyph {
-        character: '{{ glyph.character }}',
+        character: '{{ glyph.character|rust_char_escape }}',
         bitmap: &{{ glyph.codepoint }}_{{ font.name|upper }},
         xmin: {{ glyph.xmin }},
         ymin: {{ glyph.ymin }},


### PR DESCRIPTION
# Description

The problem has been solved using a custom filter for `minijinja`.

## Problem found

Even if before I thought about using `repr` as a filter, the output was `'"\'"'` for `'` character. This obviously is an error in Rust syntax.

## Solution

I found about `minijinja` custom filters, and how easy is to implement one. The one that I made does escape every character, even ones that I did not planned to use, but it's better to be safe, so now every existing character is valid (all Unicode is supported without problems).