### PR TITLE
Feat/performances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Cargo.lock
 fonts
 dhat-heap.json
 flamegraph.svg
+benchmarking

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 Cargo.lock
 fonts
+dhat-heap.json
+flamegraph.svg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ authors = ["Alessandro Bridi <ale.bridi15@gmail.com>"]
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/Bridiro/glyphr"
+
+[profile.release]
+debug = true

--- a/glyphr-macros/Cargo.toml
+++ b/glyphr-macros/Cargo.toml
@@ -19,7 +19,7 @@ syn = { version = "2.0", features = ["full", "extra-traits"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 ttf-parser = "0.25"
-minijinja = "2.10.2"
+minijinja = "2.12.0"
 
 [features]
 toml = []

--- a/glyphr-macros/Cargo.toml
+++ b/glyphr-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glyphr-macros"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors = ["Alessandro Bridi <ale.bridi15@gmail.com>"]
 description = "Set of proc-macros used to generate fonts for glyphr"

--- a/glyphr-macros/src/generator/font.rs
+++ b/glyphr-macros/src/generator/font.rs
@@ -7,17 +7,9 @@ use crate::generator::{
     sdf_generation::{SdfRaster, sdf_generate},
 };
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub struct FontSettings {
     pub collection_index: u32,
-}
-
-impl Default for FontSettings {
-    fn default() -> Self {
-        FontSettings {
-            collection_index: 0,
-        }
-    }
 }
 
 #[derive(Copy, Clone, PartialEq)]
@@ -125,7 +117,7 @@ impl Font {
             ymin: bounds.ymin as i32,
             width: bounds.width as i32,
             height: bounds.height as i32,
-            advance_width: (glyph.advance_width as f32 * scale) as i32,
+            advance_width: (glyph.advance_width * scale) as i32,
         };
 
         Some(metrics)
@@ -139,7 +131,7 @@ impl Font {
         c: char,
     ) -> Option<(Metrics, SdfRaster)> {
         if px < 1.0 {
-            panic!("Sdf render size cannot be smaller than 1.0 (got {:?})", px);
+            panic!("Sdf render size cannot be smaller than 1.0 (got {px:?})");
         }
 
         let glyph = match self.glyphs.get(&c) {

--- a/glyphr-macros/src/generator/line.rs
+++ b/glyphr-macros/src/generator/line.rs
@@ -44,21 +44,19 @@ impl Line {
                 let ky = kk * (2.0 * pa.dot(pa) + pd.dot(pb)) / 3.0;
                 let kz = kk * pd.dot(pa);
 
-                let res;
-
                 let p = ky - kx * kx;
                 let q = kx * (2.0 * kx * kx - 3.0 * ky) + kz;
                 let p3 = p * p * p;
                 let q2 = q * q;
                 let h = q2 + (4.0 * p3);
 
-                if h >= 0.0 {
+                let res = if h >= 0.0 {
                     let h = h.sqrt();
                     let x = (vec2(h, -h) - q) / 2.0;
                     let uv = x.sign() * x.abs().powf(vec2(1.0 / 3.0, 1.0 / 3.0));
                     let t = (uv[0] + uv[1] - kx).clamp(0.0, 1.0);
                     let q = pd + (pc + pb * t) * t;
-                    res = q.dot(q);
+                    q.dot(q)
                 } else {
                     let z = (-p).sqrt();
                     let v = (q / (p * z * 2.0)).acos() / 3.0;
@@ -69,8 +67,8 @@ impl Line {
                     let dx = qx.dot(qx);
                     let qy = pd + (pc + pb * t[1]) * t[1];
                     let dy = qy.dot(qy);
-                    res = dx.min(dy);
-                }
+                    dx.min(dy)
+                };
 
                 res.sqrt().abs()
             }
@@ -175,24 +173,24 @@ impl Line {
                     let r0 = -(m1 + m2) / d;
                     let r1 = -(-m1 + m2) / d;
 
-                    if 0.0 <= r0 && r0 <= 1.0 {
+                    if (0.0..=1.0).contains(&r0) {
                         out[count] = solve(r0);
                         count += 1;
                     }
 
-                    if r0 != r1 && 0.0 <= r1 && r1 <= 1.0 {
+                    if r0 != r1 && (0.0..=1.0).contains(&r1) {
                         out[count] = solve(r1);
                         count += 1;
                     }
                 } else if b != c && d == 0.0 {
                     let r0 = (2.0 * b - c) / (2.0 * b - 2.0 * c);
-                    if 0.0 <= r0 && r0 <= 1.0 {
+                    if (0.0..=1.0).contains(&r0) {
                         count = 1;
                         out[0] = solve(r0);
                     }
                 }
 
-                return count;
+                count
             }
             Self::Curve {
                 mut start,
@@ -249,7 +247,7 @@ impl Line {
                         }
 
                         let v = -c / b;
-                        if 0.0 <= v && v <= 1.0 {
+                        if (0.0..=1.0).contains(&v) {
                             out[count] = solve(v);
                             count += 1;
                         }
@@ -263,12 +261,12 @@ impl Line {
                     let v1 = (q - b) / a2;
                     let v2 = (-b - q) / a2;
 
-                    if 0.0 <= v1 && v1 <= 1.0 {
+                    if (0.0..=1.0).contains(&v1) {
                         out[count] = solve(v1);
                         count += 1;
                     }
 
-                    if v1 != v2 && 0.0 <= v2 && v2 <= 1.0 {
+                    if v1 != v2 && (0.0..=1.0).contains(&v2) {
                         out[count] = solve(v2);
                         count += 1;
                     }
@@ -301,17 +299,17 @@ impl Line {
                     let r1 = t1 * ((phi + tau) / 3.0).cos() - a / 3.0;
                     let r2 = t1 * ((phi + 2.0 * tau) / 3.0).cos() - a / 3.0;
 
-                    if 0.0 <= r0 && r0 <= 1.0 {
+                    if (0.0..=1.0).contains(&r0) {
                         out[count] = solve(r0);
                         count += 1;
                     }
 
-                    if 0.0 <= r1 && r1 <= 1.0 {
+                    if (0.0..=1.0).contains(&r1) {
                         out[count] = solve(r1);
                         count += 1;
                     }
 
-                    if 0.0 <= r2 && r2 <= 1.0 {
+                    if (0.0..=1.0).contains(&r2) {
                         out[count] = solve(r2);
                         count += 1;
                     }
@@ -323,12 +321,12 @@ impl Line {
 
                     let r0 = 2.0 * u1 - a / 3.0;
                     let r1 = -u1 - a / 3.0;
-                    if 0.0 <= r0 && r0 <= 1.0 {
+                    if (0.0..=1.0).contains(&r0) {
                         out[count] = solve(r0);
                         count += 1;
                     }
 
-                    if r0 != r1 && 0.0 <= r1 && r1 <= 1.0 {
+                    if r0 != r1 && (0.0..=1.0).contains(&r1) {
                         out[count] = solve(r1);
                         count += 1;
                     }
@@ -337,7 +335,7 @@ impl Line {
                     let u1 = crt(-q2 + sd);
                     let v1 = crt(q2 + sd);
                     let r = u1 - v1 - a / 3.0;
-                    if 0.0 <= r && r <= 1.0 {
+                    if (0.0..=1.0).contains(&r) {
                         out[count] = solve(r);
                         count += 1;
                     }

--- a/glyphr-macros/src/generator/mod.rs
+++ b/glyphr-macros/src/generator/mod.rs
@@ -48,34 +48,37 @@ pub fn generate_font(loaded_font: &crate::config::FontLoaded) -> Vec<(Vec<u8>, G
                 BitmapFormat::SDF {
                     spread: _,
                     padding: _,
-                } => {
-                    rle_encode(bitmap_sdf)
-                }
+                } => rle_encode(bitmap_sdf),
             };
-            entries.push((bitmap, GlyphEntry {
-                name: format!("GLYPH_{}", *c as u32),
-                xmin: metrics.xmin,
-                ymin: metrics.ymin,
-                width: metrics.width,
-                height: metrics.height,
-                advance_width: metrics.advance_width,
-            }));
+            entries.push((
+                bitmap,
+                GlyphEntry {
+                    name: format!("GLYPH_{}", *c as u32),
+                    xmin: metrics.xmin,
+                    ymin: metrics.ymin,
+                    width: metrics.width,
+                    height: metrics.height,
+                    advance_width: metrics.advance_width,
+                },
+            ));
         } else {
             let metrics = loaded_font.font.metrics(*c, loaded_font.px as f32);
-            if c.is_whitespace() || metrics.map_or(false, |m| m.advance_width > 0) {
+            if c.is_whitespace() || metrics.is_some_and(|m| m.advance_width > 0) {
                 eprintln!(
-                    "Info: Glyph '{}' is empty or not renderable, but has metrics. Inserting dummy entry.",
-                    c
+                    "Info: Glyph '{c}' is empty or not renderable, but has metrics. Inserting dummy entry.",
                 );
                 let met = metrics.unwrap_or_default();
-                entries.push((Vec::new(), GlyphEntry {
-                    name: format!("GLYPH_{}", *c as u32),
-                    xmin: met.xmin,
-                    ymin: met.ymin,
-                    width: met.width,
-                    height: met.height,
-                    advance_width: met.advance_width,
-                }));
+                entries.push((
+                    Vec::new(),
+                    GlyphEntry {
+                        name: format!("GLYPH_{}", *c as u32),
+                        xmin: met.xmin,
+                        ymin: met.ymin,
+                        width: met.width,
+                        height: met.height,
+                        advance_width: met.advance_width,
+                    },
+                ));
                 continue;
             }
 

--- a/glyphr-macros/src/generator/vec2.rs
+++ b/glyphr-macros/src/generator/vec2.rs
@@ -169,7 +169,7 @@ impl Index<usize> for Vec3 {
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
         match index {
-            0 | 1 | 2 => &self.v[index],
+            0..=2 => &self.v[index],
             _ => panic!("Vec2 index value must be 0, 1, or 2"),
         }
     }

--- a/glyphr-macros/src/lib.rs
+++ b/glyphr-macros/src/lib.rs
@@ -21,7 +21,7 @@ pub fn generate_font(input: TokenStream) -> TokenStream {
     match rendered.parse() {
         Ok(parsed) => parsed,
         Err(e) => {
-            panic!("Failed to generate font: {}", e)
+            panic!("Failed to generate font: {e}")
         }
     }
 }
@@ -42,7 +42,7 @@ pub fn generate_fonts_from_toml(input: TokenStream) -> TokenStream {
         Err(err) => {
             return syn::Error::new_spanned(
                 file_path,
-                format!("Failed to read file '{}': {}", path_str, err),
+                format!("Failed to read file '{path_str}': {err}"),
             )
             .to_compile_error()
             .into();
@@ -57,7 +57,7 @@ pub fn generate_fonts_from_toml(input: TokenStream) -> TokenStream {
     match rendered.parse() {
         Ok(parsed) => parsed,
         Err(e) => {
-            panic!("Failed to generate font: {}", e)
+            panic!("Failed to generate font: {e}")
         }
     }
 }

--- a/glyphr-macros/src/macro_parser.rs
+++ b/glyphr-macros/src/macro_parser.rs
@@ -1,6 +1,6 @@
-use syn::{Error, Ident, LitFloat, LitInt, LitStr, Token, parse::Parse};
 use std::fs;
 use std::path::Path;
+use syn::{Error, Ident, LitFloat, LitInt, LitStr, Token, parse::Parse};
 
 use crate::config::{BitmapFormat, FontLoaded, ToFontLoaded, parse_char_set};
 use crate::generator::font::Font;
@@ -18,13 +18,11 @@ impl ToFontLoaded for FontConfig {
     fn to_font_loaded(&self) -> Vec<FontLoaded> {
         let mut fonts = Vec::new();
 
-        let ttf_file = fs::read(Path::new(&self.path)).expect(&format!(
-            "can't read ttf file at path: {}",
-            self.path
-        ));
+        let ttf_file = fs::read(Path::new(&self.path))
+            .unwrap_or_else(|_| panic!("can't read ttf file at path: {}", self.path));
         let font = Font::from_bytes(ttf_file.as_slice(), Default::default())
             .expect("failed to parse ttf file");
-        
+
         let font = FontLoaded {
             name: self.name.to_string(),
             font,

--- a/glyphr-macros/src/toml_parser.rs
+++ b/glyphr-macros/src/toml_parser.rs
@@ -27,9 +27,9 @@ impl ToFontLoaded for TomlConfig {
 
         for toml_font in &self.font {
             let ttf_file = fs::read(Path::new(&toml_font.path))
-                .expect(&format!("can't read ttf file at path: {}", toml_font.path));
+                .unwrap_or_else(|_| panic!("can't read ttf file at path: {}", toml_font.path));
             let font = Font::from_bytes(ttf_file.as_slice(), Default::default())
-                .expect("failed to parse ttf file");
+                .unwrap_or_else(|_| panic!("failed to parse ttf file"));
             fonts.push(FontLoaded {
                 name: toml_font.name.to_string(),
                 font,

--- a/glyphr/Cargo.toml
+++ b/glyphr/Cargo.toml
@@ -10,14 +10,12 @@ categories = ["no-std", "no-std::no-alloc", "graphics", "embedded"]
 repository = "https://github.com/Bridiro/glyphr"
 
 [dependencies]
-dhat = { version = "0.3.3", optional = true }
 minifb = { version = "0.28", optional = true }
 glyphr-macros = { path = "../glyphr-macros", version = "0.1" }
 
 [features]
 default = ["toml"]
 window = ["dep:minifb"]
-dhat-heap = ["dep:dhat"]
 toml = ["glyphr-macros/toml"]
 
 [[example]]

--- a/glyphr/Cargo.toml
+++ b/glyphr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glyphr"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 authors = ["Alessandro Bridi <ale.bridi15@gmail.com>"]
 description = "A no_std, lightweight and simple font rasterizing library"
@@ -11,7 +11,7 @@ repository = "https://github.com/Bridiro/glyphr"
 
 [dependencies]
 minifb = { version = "0.28", optional = true }
-glyphr-macros = { path = "../glyphr-macros", version = "0.1" }
+glyphr-macros = { path = "../glyphr-macros", version = "0.1.2" }
 
 [features]
 default = ["toml"]

--- a/glyphr/Cargo.toml
+++ b/glyphr/Cargo.toml
@@ -21,5 +21,5 @@ dhat-heap = ["dep:dhat"]
 toml = ["glyphr-macros/toml"]
 
 [[example]]
-name = "glyphr_test_window"
-required-features = ["window", "toml"]
+name = "glyphr_test"
+required-features = ["toml"]

--- a/glyphr/Cargo.toml
+++ b/glyphr/Cargo.toml
@@ -10,12 +10,14 @@ categories = ["no-std", "no-std::no-alloc", "graphics", "embedded"]
 repository = "https://github.com/Bridiro/glyphr"
 
 [dependencies]
+dhat = { version = "0.3.3", optional = true }
 minifb = { version = "0.28", optional = true }
 glyphr-macros = { path = "../glyphr-macros", version = "0.1" }
 
 [features]
 default = ["toml"]
 window = ["dep:minifb"]
+dhat-heap = ["dep:dhat"]
 toml = ["glyphr-macros/toml"]
 
 [[example]]

--- a/glyphr/README.md
+++ b/glyphr/README.md
@@ -47,5 +47,5 @@ renderer.render(&mut target, "Hello World!", POPPINS, 100, 50, TextAlign { horiz
 > [!TIP]
 > If you want to run an example on your machine you can just do:
 > ```rust
-> cargo run --example glyphr_test_window --features window
+> cargo run --example glyphr_test --features "toml window"
 > ```

--- a/glyphr/examples/glyphr_test.rs
+++ b/glyphr/examples/glyphr_test.rs
@@ -1,4 +1,5 @@
 use glyphr::{AlignH, AlignV, BufferTarget, Glyphr, RenderConfig, SdfConfig, TextAlign};
+#[cfg(feature = "window")]
 use minifb::{Window, WindowOptions};
 
 const WIDTH: usize = 800;
@@ -14,6 +15,7 @@ fn main() {
 
     let mut buffer: [u32; WIDTH * HEIGHT] = [0; WIDTH * HEIGHT];
 
+    #[cfg(feature = "window")]
     let mut window = Window::new(
         "Pixel Buffer Test",
         WIDTH,
@@ -23,6 +25,7 @@ fn main() {
         },
     )
     .expect("Failed to create window");
+
     for x in 0..WIDTH {
         buffer[120 * WIDTH + x] = 0xffffffff;
         buffer[240 * WIDTH + x] = 0xffffffff;
@@ -106,6 +109,7 @@ fn main() {
         )
         .unwrap();
 
+    #[cfg(feature = "window")]
     while window.is_open() && !window.is_key_down(minifb::Key::Escape) {
         window.update_with_buffer(&buffer, WIDTH, HEIGHT).unwrap();
     }

--- a/glyphr/examples/glyphr_test.rs
+++ b/glyphr/examples/glyphr_test.rs
@@ -5,14 +5,7 @@ use minifb::{Window, WindowOptions};
 const WIDTH: usize = 800;
 const HEIGHT: usize = 480;
 
-#[cfg(feature = "dhat-heap")]
-#[global_allocator]
-static ALLOC: dhat::Alloc = dhat::Alloc;
-
 fn main() {
-    #[cfg(feature = "dhat-heap")]
-    let _profiler = dhat::Profiler::new_heap();
-
     let mut buffer: [u32; WIDTH * HEIGHT] = [0; WIDTH * HEIGHT];
 
     #[cfg(feature = "window")]

--- a/glyphr/examples/glyphr_test_window.rs
+++ b/glyphr/examples/glyphr_test_window.rs
@@ -4,7 +4,14 @@ use minifb::{Window, WindowOptions};
 const WIDTH: usize = 800;
 const HEIGHT: usize = 480;
 
-fn test_pixel_buffer_with_window() {
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+fn main() {
+    #[cfg(feature = "dhat-heap")]
+    let _profiler = dhat::Profiler::new_heap();
+
     let mut buffer: [u32; WIDTH * HEIGHT] = [0; WIDTH * HEIGHT];
 
     let mut window = Window::new(
@@ -102,8 +109,4 @@ fn test_pixel_buffer_with_window() {
     while window.is_open() && !window.is_key_down(minifb::Key::Escape) {
         window.update_with_buffer(&buffer, WIDTH, HEIGHT).unwrap();
     }
-}
-
-fn main() {
-    test_pixel_buffer_with_window();
 }

--- a/glyphr/src/api.rs
+++ b/glyphr/src/api.rs
@@ -144,6 +144,13 @@ pub struct Glyphr {
     render_config: RenderConfig,
 }
 
+impl Default for Glyphr {
+    /// Create a new text renderer with default configuration.
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Glyphr {
     /// Create a new text renderer with default configuration.
     pub fn new() -> Self {

--- a/glyphr/src/renderer.rs
+++ b/glyphr/src/renderer.rs
@@ -7,8 +7,10 @@
 use crate::{
     BitmapFormat, Glyphr, GlyphrError, RenderTarget,
     font::{Font, Glyph},
-    utils::{ExtFloor, mix, smoothstep},
+    utils::{ExtFloor, smoothstep},
 };
+
+use core::cmp::{max as cmax, min as cmin};
 
 /// Renders a glyph at a given position.
 pub fn render_glyph<T: RenderTarget>(
@@ -30,51 +32,209 @@ pub fn render_glyph<T: RenderTarget>(
     Ok(())
 }
 
-/// Renders an SDF-encoded glyph applying smoothing.
+#[inline(always)]
+fn bilerp(p00: f32, p10: f32, p01: f32, p11: f32, wx: f32, wy: f32) -> f32 {
+    // Fused bilinear interpolation (no function calls to `mix` in hot loop).
+    let top = p00 + wx * (p10 - p00);
+    let bottom = p01 + wx * (p11 - p01);
+    top + wy * (bottom - top)
+}
+
+/// A forward-only cursor to read values from an RLE [count, value] stream
+/// in *decoded index* order. Works in O(1) amortized for monotonically
+/// increasing target indices (our case).
+#[derive(Clone, Copy)]
+struct RleCursor<'a> {
+    buf: &'a [u8],
+    i: usize,
+    run_c: usize,
+    val: u8,
+    dec: usize,
+}
+
+impl<'a> RleCursor<'a> {
+    #[inline(always)]
+    fn new(buf: &'a [u8]) -> Self {
+        let mut c = Self {
+            buf,
+            i: 0,
+            run_c: 0,
+            val: 0,
+            dec: 0,
+        };
+        c.load_next_run();
+        c
+    }
+
+    #[inline(always)]
+    fn load_next_run(&mut self) {
+        if self.i + 1 < self.buf.len() {
+            let count = self.buf[self.i] as usize;
+            let value = self.buf[self.i + 1];
+            self.dec += self.run_c;
+            self.i += 2;
+            self.run_c = count;
+            self.val = value;
+        } else {
+            // Exhausted stream
+            self.dec += self.run_c;
+            self.run_c = 0;
+            self.val = 0;
+            self.i = self.buf.len();
+        }
+    }
+
+    /// Advance forward until the run that *contains* `target_dec_idx`.
+    /// `target_dec_idx` must be >= current decoded index for best performance.
+    #[inline(always)]
+    fn advance_to(&mut self, target_dec_idx: usize) {
+        // If target is before current run start, we can't go backwards (shouldn't happen
+        // in our monotonic usage). We'll just fall back to full rescan if it occurs.
+        if target_dec_idx < self.dec {
+            // Rare/unsafe path: rescan from the beginning (still O(N), but should not happen).
+            *self = RleCursor::new(self.buf);
+        }
+        // Move runs forward until target is inside [dec .. dec + run_c)
+        while self.run_c == 0 || target_dec_idx >= self.dec + self.run_c {
+            if self.run_c == 0 && self.i >= self.buf.len() {
+                // End of stream
+                return;
+            }
+            self.load_next_run();
+        }
+        // Now target lies in current run
+    }
+
+    /// Get the value at `target_dec_idx`, advancing forward as needed.
+    #[inline(always)]
+    fn get(&mut self, target_dec_idx: usize) -> u8 {
+        self.advance_to(target_dec_idx);
+        self.val
+    }
+}
+
+/// Renders an SDF-encoded glyph applying smoothing (Y-major scan, RLE-cursor optimized).
 fn render_glyph_sdf<T: RenderTarget>(
-    x: i32,
-    y: i32,
+    dst_x: i32,
+    dst_y: i32,
     glyph: &Glyph,
     state: &Glyphr,
     scale: f32,
     target: &mut T,
 ) -> Result<(), GlyphrError> {
-    let width = (glyph.width as f32 * scale) as u32;
-    let height = (glyph.height as f32 * scale) as u32;
+    // Scaled output size
+    let out_w = (glyph.width as f32 * scale) as i32;
+    let out_h = (glyph.height as f32 * scale) as i32;
 
-    let width_f = width as f32;
-    let height_f = height as f32;
+    if out_w <= 0 || out_h <= 0 {
+        return Ok(());
+    }
 
-    let distance_to_pixel = |distance: f32| match distance > state.config().sdf.mid_value {
-        true => {
-            (smoothstep(
-                state.config().sdf.mid_value - state.config().sdf.smoothing,
-                state.config().sdf.mid_value + state.config().sdf.smoothing,
-                distance,
-            ) * 255.0) as u8
-        }
-        false => 0,
-    };
+    let (tgt_w_u, tgt_h_u) = target.dimensions();
+    let tgt_w = tgt_w_u as i32;
+    let tgt_h = tgt_h_u as i32;
 
-    let (target_w, target_h) = target.dimensions();
+    // Clipping to target bounds (early reject off-screen regions)
+    let x0 = cmax(0, dst_x);
+    let y0 = cmax(0, dst_y);
+    let x1 = cmin(dst_x + out_w, tgt_w);
+    let y1 = cmin(dst_y + out_h, tgt_h);
+    if x0 >= x1 || y0 >= y1 {
+        return Ok(());
+    }
 
-    for x_1 in 0..width as i32 {
-        for y_1 in 0..height as i32 {
-            if x_1 + x >= 0
-                && x_1 + x < target_w as i32
-                && y_1 + y >= 0
-                && y_1 + y < target_h as i32
-            {
-                let sample_x = ((x_1 as f32) + 0.5) / width_f;
-                let sample_y = ((y_1 as f32) + 0.5) / height_f;
+    // Precompute constants
+    let inv255: f32 = 1.0 / 255.0;
+    let src_w = glyph.width as usize;
+    let src_h = glyph.height as usize;
 
-                let sampled_distance = sdf_sample(&glyph, sample_x, sample_y);
-                let alpha = distance_to_pixel(sampled_distance) as u32;
-                if alpha > 0 {
-                    let blended_color = (alpha << 24) | (state.config().color & 0x00ffffff);
-                    if !target.write_pixel((x_1 + x) as u32, (y_1 + y) as u32, blended_color) {
-                        return Err(GlyphrError::InvalidTarget);
-                    }
+    // Normalize factors to map output pixel centers to source [0,1] space.
+    let inv_out_w = 1.0f32 / (out_w as f32);
+    let inv_out_h = 1.0f32 / (out_h as f32);
+
+    // SDF smoothing params (pulled out of the loop)
+    let cfg = state.config();
+    let mid = cfg.sdf.mid_value;
+    let smoothing = cfg.sdf.smoothing;
+    let lo = mid - smoothing;
+    let hi = mid + smoothing;
+
+    // A single base cursor that moves only forward as y increases.
+    let mut base_cur = RleCursor::new(glyph.bitmap);
+
+    // Iterate output rows (Y-major), cache two row cursors for top & bottom source rows.
+    for oy in y0..y1 {
+        // Map to source fractional row in [0, src_h)
+        let sy = ((oy - dst_y) as f32 + 0.5) * inv_out_h * (src_h as f32) - 0.5;
+        let sy_clamped = if sy < 0.0 { 0.0 } else { sy }; // no negative sampling
+        let top = (sy_clamped.floor() as isize).clamp(0, (src_h as isize) - 1) as usize;
+        let wy = sy_clamped - (top as f32);
+        let bottom = cmin(top + 1, src_h.saturating_sub(1));
+
+        // Locate the *decoded* start index for the rows we need.
+        // Because oy increases, row_start_top is non-decreasing -> base_cur only moves forward.
+        let row_start_top = top * src_w;
+        let row_start_bottom = bottom * src_w;
+
+        base_cur.advance_to(row_start_top);
+        let mut cur_top = base_cur;
+        let mut cur_bot = base_cur;
+        cur_bot.advance_to(row_start_bottom);
+
+        // We walk across X in increasing order, so decoded indices are monotonic as well.
+        let mut last_left_dec_top = row_start_top;
+        let mut last_left_dec_bottom = row_start_bottom;
+
+        for ox in x0..x1 {
+            // Map to source fractional column in [0, src_w)
+            let sx = ((ox - dst_x) as f32 + 0.5) * inv_out_w * (src_w as f32) - 0.5;
+            let sx_clamped = if sx < 0.0 { 0.0 } else { sx };
+            let left = (sx_clamped.floor() as isize).clamp(0, (src_w as isize) - 1) as usize;
+            let wx = sx_clamped - (left as f32);
+            let right = cmin(left + 1, src_w.saturating_sub(1));
+
+            // Global decoded indices for the four neighbors (monotone across ox)
+            let li_top = row_start_top + left;
+            let ri_top = row_start_top + right;
+            let li_bot = row_start_bottom + left;
+            let ri_bot = row_start_bottom + right;
+
+            // Advance row cursors forward as needed (mostly +0 or +1 per step)
+            if li_top > last_left_dec_top {
+                cur_top.advance_to(li_top);
+                last_left_dec_top = li_top;
+            }
+            let p00 = cur_top.get(li_top);
+            let p10 = cur_top.get(ri_top);
+
+            if li_bot > last_left_dec_bottom {
+                cur_bot.advance_to(li_bot);
+                last_left_dec_bottom = li_bot;
+            }
+            let p01 = cur_bot.get(li_bot);
+            let p11 = cur_bot.get(ri_bot);
+
+            // Normalize once via multiply (cheaper than /255.0 on MCUs)
+            let p00f = (p00 as f32) * inv255;
+            let p10f = (p10 as f32) * inv255;
+            let p01f = (p01 as f32) * inv255;
+            let p11f = (p11 as f32) * inv255;
+
+            let dist = bilerp(p00f, p10f, p01f, p11f, wx, wy);
+
+            // Keep your original gating behavior (only smoothstep if > mid).
+            // Pull constants out of loop; smoothstep is likely cheap enough.
+            let alpha_u8 = if dist > mid {
+                (smoothstep(lo, hi, dist) * 255.0) as u8
+            } else {
+                0
+            };
+
+            if alpha_u8 != 0 {
+                let alpha = (alpha_u8 as u32) << 24;
+                let blended_color = alpha | (cfg.color & 0x00ff_ffff);
+                if !target.write_pixel(ox as u32, oy as u32, blended_color) {
+                    return Err(GlyphrError::InvalidTarget);
                 }
             }
         }
@@ -83,31 +243,42 @@ fn render_glyph_sdf<T: RenderTarget>(
     Ok(())
 }
 
-/// Renders a Bitmap-encoded glyph.
+/// Renders a Bitmap-encoded glyph (bit-packed): Y-major, early clipping, fewer repeated checks.
 fn render_glyph_bitmap<T: RenderTarget>(
-    x: i32,
-    y: i32,
+    dst_x: i32,
+    dst_y: i32,
     glyph: &Glyph,
     state: &Glyphr,
     target: &mut T,
 ) -> Result<(), GlyphrError> {
-    let width = glyph.width;
-    let height = glyph.height;
+    let w = glyph.width;
+    let h = glyph.height;
 
-    let (target_w, target_h) = target.dimensions();
+    if w <= 0 || h <= 0 {
+        return Ok(());
+    }
 
-    for x_1 in 0..width as i32 {
-        for y_1 in 0..height as i32 {
-            if x_1 + x >= 0
-                && x_1 + x < target_w as i32
-                && y_1 + y >= 0
-                && y_1 + y < target_h as i32
-            {
-                if bitmap_value_at(glyph, x_1, y_1)? {
-                    let blended_color = (0xff << 24) | (state.config().color & 0x00ffffff);
-                    if !target.write_pixel((x_1 + x) as u32, (y_1 + y) as u32, blended_color) {
-                        return Err(GlyphrError::InvalidTarget);
-                    }
+    let (tgt_w_u, tgt_h_u) = target.dimensions();
+    let tgt_w = tgt_w_u as i32;
+    let tgt_h = tgt_h_u as i32;
+
+    let x0 = cmax(0, dst_x);
+    let y0 = cmax(0, dst_y);
+    let x1 = cmin(dst_x + w, tgt_w);
+    let y1 = cmin(dst_y + h, tgt_h);
+    if x0 >= x1 || y0 >= y1 {
+        return Ok(());
+    }
+
+    let color = (0xffu32 << 24) | (state.config().color & 0x00ff_ffff);
+
+    for oy in y0..y1 {
+        let y_src = oy - dst_y;
+        for ox in x0..x1 {
+            let x_src = ox - dst_x;
+            if bitmap_value_at(glyph, x_src, y_src)? {
+                if !target.write_pixel(ox as u32, oy as u32, color) {
+                    return Err(GlyphrError::InvalidTarget);
                 }
             }
         }
@@ -121,57 +292,11 @@ pub fn advance(c: char, font: Font) -> Result<i32, GlyphrError> {
     Ok(font.find_glyph(c)?.advance_width)
 }
 
-// This function samples the nearest 4 pixels to `x` and `y`, then does a bilinear interpolation
-// and finds the average of them.
-fn sdf_sample(glyph: &Glyph, x: f32, y: f32) -> f32 {
-    let gx = (x * (glyph.width as f32) - 0.5).max(0.0);
-    let gy = (y * (glyph.height as f32) - 0.5).max(0.0);
-    let left = gx.floor() as usize;
-    let top = gy.floor() as usize;
-    let wx = gx - (left as f32);
-    let wy = gy - (top as f32);
-
-    let right = (left + 1).min((glyph.width - 1) as usize);
-    let bottom = (top + 1).min((glyph.height - 1) as usize);
-
-    let row_size = glyph.width as usize;
-    let get_pixel = |x_1, y_1| rle_decode_at(glyph.bitmap, (row_size * y_1) + x_1 as usize);
-
-    let p00 = get_pixel(left, top);
-    let p10 = get_pixel(right, top);
-    let p01 = get_pixel(left, bottom);
-    let p11 = get_pixel(right, bottom);
-
-    mix(
-        mix(p00 as f32 / 255.0, p10 as f32 / 255.0, wx),
-        mix(p01 as f32 / 255.0, p11 as f32 / 255.0, wx),
-        wy,
-    )
-}
-
-/// Returns the value that would be found at a given index in a non-encoded array.
-fn rle_decode_at(buffer: &[u8], index: usize) -> u8 {
-    let mut i = 0;
-    let mut decoded_index = 0;
-    while i < buffer.len() {
-        let count = buffer[i] as usize;
-        let value = buffer[i + 1];
-        if decoded_index + count > index {
-            return value;
-        }
-        decoded_index += count;
-        i += 2;
-    }
-    0
-}
-
-/// This function firstly finds the byte in which the bit we're searching for is stored, then
-/// extracts is and returns a boolean (for 1 or 0) (or error for invalid coordinates).
+/// Return a bit from a packed 1bpp bitmap.
 fn bitmap_value_at(glyph: &Glyph, x: i32, y: i32) -> Result<bool, GlyphrError> {
     if x < 0 || y < 0 || x >= glyph.width || y >= glyph.height {
         return Err(GlyphrError::OutOfBounds);
     }
-
     let bit_index = y * glyph.width + x;
     let byte_index = (bit_index / 8) as usize;
     let bit_offset = (bit_index % 8) as u8;
@@ -179,21 +304,84 @@ fn bitmap_value_at(glyph: &Glyph, x: i32, y: i32) -> Result<bool, GlyphrError> {
     if byte_index >= glyph.bitmap.len() {
         return Err(GlyphrError::OutOfBounds);
     }
-
     let byte = glyph.bitmap[byte_index];
     let bit = (byte >> (7 - bit_offset)) & 1;
-
     Ok(bit == 1)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::RleCursor;
 
     #[test]
-    fn test_rle_decode_at() {
-        let buffer = [255, 255];
-        let val = rle_decode_at(&buffer, 128);
-        assert_eq!(val, 255);
+    fn single_run() {
+        // Stream encodes: 3 x 42
+        let buf = [3u8, 42];
+        let mut cur = RleCursor::new(&buf);
+
+        assert_eq!(cur.get(0), 42);
+        assert_eq!(cur.get(1), 42);
+        assert_eq!(cur.get(2), 42);
+    }
+
+    #[test]
+    fn multiple_runs() {
+        // Stream encodes: [2 x 10, 3 x 20]
+        let buf = [2, 10, 3, 20];
+        let mut cur = RleCursor::new(&buf);
+
+        assert_eq!(cur.get(0), 10);
+        assert_eq!(cur.get(1), 10);
+        assert_eq!(cur.get(2), 20);
+        assert_eq!(cur.get(3), 20);
+        assert_eq!(cur.get(4), 20);
+    }
+
+    #[test]
+    fn monotonic_advance() {
+        // Stream encodes: [1 x 1, 1 x 2, 1 x 3, 1 x 4]
+        let buf = [1, 1, 1, 2, 1, 3, 1, 4];
+        let mut cur = RleCursor::new(&buf);
+
+        // Forward only
+        for i in 0..4 {
+            assert_eq!(cur.get(i), (i + 1) as u8);
+        }
+    }
+
+    #[test]
+    fn non_monotonic_access_forces_rescan() {
+        // Stream encodes: [3 x 7, 2 x 9]
+        let buf = [3, 7, 2, 9];
+        let mut cur = RleCursor::new(&buf);
+
+        // Forward is fine
+        assert_eq!(cur.get(0), 7);
+        assert_eq!(cur.get(3), 9);
+
+        // Now request earlier index (non-monotonic)
+        assert_eq!(cur.get(1), 7);
+    }
+
+    #[test]
+    fn end_of_stream_behavior() {
+        // Stream encodes: [2 x 5]
+        let buf = [2, 5];
+        let mut cur = RleCursor::new(&buf);
+
+        assert_eq!(cur.get(0), 5);
+        assert_eq!(cur.get(1), 5);
+        // Out of bounds -> stays at last run value
+        assert_eq!(cur.get(2), 0);
+    }
+
+    #[test]
+    fn empty_stream() {
+        let buf: [u8; 0] = [];
+        let mut cur = RleCursor::new(&buf);
+
+        // Any access should return 0
+        assert_eq!(cur.get(0), 0);
+        assert_eq!(cur.get(10), 0);
     }
 }

--- a/glyphr/src/renderer.rs
+++ b/glyphr/src/renderer.rs
@@ -276,10 +276,10 @@ fn render_glyph_bitmap<T: RenderTarget>(
         let y_src = oy - dst_y;
         for ox in x0..x1 {
             let x_src = ox - dst_x;
-            if bitmap_value_at(glyph, x_src, y_src)? {
-                if !target.write_pixel(ox as u32, oy as u32, color) {
-                    return Err(GlyphrError::InvalidTarget);
-                }
+            if bitmap_value_at(glyph, x_src, y_src)?
+                && !target.write_pixel(ox as u32, oy as u32, color)
+            {
+                return Err(GlyphrError::InvalidTarget);
             }
         }
     }

--- a/glyphr/src/utils.rs
+++ b/glyphr/src/utils.rs
@@ -29,11 +29,6 @@ pub fn smoothstep(edge0: f32, edge1: f32, x: f32) -> f32 {
     t * t * (3.0 - 2.0 * t)
 }
 
-/// Linearly interpolates between two values.
-pub fn mix(v1: f32, v2: f32, weight: f32) -> f32 {
-    v1 + (v2 - v1) * weight
-}
-
 #[cfg(test)]
 mod tests {
     #[test]
@@ -51,13 +46,6 @@ mod tests {
         assert_eq!(super::smoothstep(0.0, 1.0, 0.5), 0.5);
         assert_eq!(super::smoothstep(0.0, 1.0, 1.0), 1.0);
         assert_eq!(super::smoothstep(0.0, 1.0, 2.0), 1.0);
-    }
-
-    #[test]
-    fn test_mix_behavior() {
-        assert_eq!(super::mix(0.0, 10.0, 0.0), 0.0);
-        assert_eq!(super::mix(0.0, 10.0, 0.5), 5.0);
-        assert_eq!(super::mix(0.0, 10.0, 1.0), 10.0);
     }
 }
 

--- a/glyphr/src/utils.rs
+++ b/glyphr/src/utils.rs
@@ -48,4 +48,3 @@ mod tests {
         assert_eq!(super::smoothstep(0.0, 1.0, 2.0), 1.0);
     }
 }
-


### PR DESCRIPTION
# What has been done

I decided to not use `cargo bench`, but instead focus on external profilers such as `flamegraph`, that is more than enough to find hotspots.

## What has been found

Using `flamegraph` I found out that the function `sdf_sample` was **HUGE**, and it was taking up 80% of the total runtime.
This was not acceptable and so I decided to change approach. I found that inside that same function, another huge hotspot was `rle_decode_at`, that for my mistake was burning clock cycles.

## Optimizations!!!

I completely rewrote the RLE implementation, now with caching and forward pointers to not pass twice in the array, so that I keep it as direct as possible. This improved performances hugely:
| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `./glyphr_old_rle` | 8.6 ± 0.7 | 7.7 | 23.8 | 5.65 ± 0.84 |
| `./glyphr_new_rle` | 1.5 ± 0.2 | 1.4 | 5.5 | 1.00 |

this shows a 6x in performances (the test was of course with the same drawn text, font and size).

### Formatting and good practices

I also applied  nearly every suggestion from `cargo clippy` and formatted using `cargo fmt` to keep the whole codebase homogeneous.
